### PR TITLE
Brie/asset id update

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,7 +1,10 @@
+source 'https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git'
+
 use_frameworks!
 
 target 'Segment-Nielsen-DCR_Example' do
   pod 'Segment-Nielsen-DCR', :path => '../'
+  pod 'NielsenAppSDK'
 
   target 'Segment-Nielsen-DCR_Tests' do
     inherit! :search_paths

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,10 +1,7 @@
-source 'https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git'
-
 use_frameworks!
 
 target 'Segment-Nielsen-DCR_Example' do
   pod 'Segment-Nielsen-DCR', :path => '../'
-  pod 'NielsenAppSDK'
 
   target 'Segment-Nielsen-DCR_Tests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,18 +1,30 @@
 PODS:
   - Analytics (3.6.3)
   - Expecta (1.0.6)
+  - NielsenAppSDK (6.2.0.0)
   - OCHamcrest (6.1.1)
   - OCMockito (4.1.0):
     - OCHamcrest (~> 6.0)
-  - Segment-Nielsen-DCR (1.0.0):
+  - Segment-Nielsen-DCR (1.1.2):
     - Analytics (~> 3.6)
   - Specta (1.0.6)
 
 DEPENDENCIES:
   - Expecta
+  - NielsenAppSDK
   - OCMockito
   - Segment-Nielsen-DCR (from `../`)
   - Specta
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Analytics
+    - Expecta
+    - OCHamcrest
+    - OCMockito
+    - Specta
+  https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git:
+    - NielsenAppSDK
 
 EXTERNAL SOURCES:
   Segment-Nielsen-DCR:
@@ -21,11 +33,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Analytics: be561304471ed2aa58c4881fea59362dc7bbb4a5
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
+  NielsenAppSDK: be0732f26810c30d4353148d433cfe9da4bf2f96
   OCHamcrest: 363e1bf738c3e8a94abe7c2c415f70d671adde38
   OCMockito: bceefcd365252bcdf8b59c1b2bd23890805fc0d8
-  Segment-Nielsen-DCR: 624e9e70b177e160f5c14566e753f3eeca49e4ce
+  Segment-Nielsen-DCR: 90eadf03d4de5d499cbc604abaab8d0da8ad4fd1
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
-PODFILE CHECKSUM: e793c123c1317f200d9e9259817fe1554d7e08ed
+PODFILE CHECKSUM: 159d4fcb2ada11924913df078471eb5a947a7a17
 
-COCOAPODS: 1.2.1
+COCOAPODS: 1.7.3

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,6 @@
 PODS:
   - Analytics (3.6.3)
   - Expecta (1.0.6)
-  - NielsenAppSDK (6.2.0.0)
   - OCHamcrest (6.1.1)
   - OCMockito (4.1.0):
     - OCHamcrest (~> 6.0)
@@ -11,7 +10,6 @@ PODS:
 
 DEPENDENCIES:
   - Expecta
-  - NielsenAppSDK
   - OCMockito
   - Segment-Nielsen-DCR (from `../`)
   - Specta
@@ -23,8 +21,6 @@ SPEC REPOS:
     - OCHamcrest
     - OCMockito
     - Specta
-  https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git:
-    - NielsenAppSDK
 
 EXTERNAL SOURCES:
   Segment-Nielsen-DCR:
@@ -33,12 +29,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Analytics: be561304471ed2aa58c4881fea59362dc7bbb4a5
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  NielsenAppSDK: be0732f26810c30d4353148d433cfe9da4bf2f96
   OCHamcrest: 363e1bf738c3e8a94abe7c2c415f70d671adde38
   OCMockito: bceefcd365252bcdf8b59c1b2bd23890805fc0d8
   Segment-Nielsen-DCR: 90eadf03d4de5d499cbc604abaab8d0da8ad4fd1
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
-PODFILE CHECKSUM: 159d4fcb2ada11924913df078471eb5a947a7a17
+PODFILE CHECKSUM: e793c123c1317f200d9e9259817fe1554d7e08ed
 
 COCOAPODS: 1.7.3

--- a/Example/Segment-Nielsen-DCR.xcodeproj/project.pbxproj
+++ b/Example/Segment-Nielsen-DCR.xcodeproj/project.pbxproj
@@ -270,7 +270,6 @@
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
 				EA71D17187E3055A8D6AF5DC /* [CP] Embed Pods Frameworks */,
-				1ABFB6C6A3480E4F8EDD07A2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -290,7 +289,6 @@
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
 				F6010FD55820175AAF601EEF /* [CP] Embed Pods Frameworks */,
-				F2134AA37B17C8956D532BA9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -360,34 +358,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1ABFB6C6A3480E4F8EDD07A2 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Segment-Nielsen-DCR_Example/Pods-Segment-Nielsen-DCR_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		7694E17DE89165C80B5A50F9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Segment-Nielsen-DCR_Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C385464FCA6945C12A128B34 /* [CP] Check Pods Manifest.lock */ = {
@@ -396,13 +382,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Segment-Nielsen-DCR_Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		EA71D17187E3055A8D6AF5DC /* [CP] Embed Pods Frameworks */ = {
@@ -411,28 +400,18 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Segment-Nielsen-DCR_Example/Pods-Segment-Nielsen-DCR_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Analytics/Analytics.framework",
+				"${PODS_ROOT}/NielsenAppSDK/NielsenAppApi.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Analytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NielsenAppApi.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Segment-Nielsen-DCR_Example/Pods-Segment-Nielsen-DCR_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F2134AA37B17C8956D532BA9 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Segment-Nielsen-DCR_Tests/Pods-Segment-Nielsen-DCR_Tests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Segment-Nielsen-DCR_Example/Pods-Segment-Nielsen-DCR_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F6010FD55820175AAF601EEF /* [CP] Embed Pods Frameworks */ = {
@@ -441,13 +420,22 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Segment-Nielsen-DCR_Tests/Pods-Segment-Nielsen-DCR_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
+				"${BUILT_PRODUCTS_DIR}/OCHamcrest/OCHamcrest.framework",
+				"${BUILT_PRODUCTS_DIR}/OCMockito/OCMockito.framework",
+				"${BUILT_PRODUCTS_DIR}/Specta/Specta.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCHamcrest.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMockito.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Segment-Nielsen-DCR_Tests/Pods-Segment-Nielsen-DCR_Tests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Segment-Nielsen-DCR_Tests/Pods-Segment-Nielsen-DCR_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/Segment-Nielsen-DCR.xcodeproj/project.pbxproj
+++ b/Example/Segment-Nielsen-DCR.xcodeproj/project.pbxproj
@@ -402,12 +402,10 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Segment-Nielsen-DCR_Example/Pods-Segment-Nielsen-DCR_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Analytics/Analytics.framework",
-				"${PODS_ROOT}/NielsenAppSDK/NielsenAppApi.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Analytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NielsenAppApi.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
+++ b/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
@@ -17,10 +17,25 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     //https://segment.com/ladanazita/sources/video/debugger
-    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"nu3idUpAunUqh7pJWwFsgUKg7qTo7Ouz"];
+    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"5BZlN8itngsm46QK8k0sdWBjEYlam2RM"];
     [config use:[SEGNielsenDCRIntegrationFactory instance]];
     [SEGAnalytics setupWithConfiguration:config];
     [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
+    [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
+                           properties: @{ @"full_episode": @true }
+                              options: @{
+                                @"integrations": @{
+                                        @"nielsen-dcr": @{
+                                          @"pipmode": @"2017-05-22",
+                                          @"adLoadType": @"c3 value",
+                                          @"channelName": @"c4 value",
+                                          @"mediaUrl": @"c6 value",
+                                          @"hasAds": @true,
+                                          @"crossId1": @"cross id1 value",
+                                          @"crossId2": @"cross id2 value"
+                                         }
+                                       }
+                            }];
 
     [[SEGAnalytics sharedAnalytics] flush];
     [SEGAnalytics debug:YES];

--- a/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
+++ b/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
@@ -17,12 +17,12 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     //https://segment.com/ladanazita/sources/video/debugger
-    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"5BZlN8itngsm46QK8k0sdWBjEYlam2RM"];
+    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY_HERE"];
     [config use:[SEGNielsenDCRIntegrationFactory instance]];
     [SEGAnalytics setupWithConfiguration:config];
     [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
     [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
-                           properties: @{ @"full_episode": @true }
+                           properties: @{ @"full_episode": @true, @"tms_video_id": @"3ru239ur829u4u8t480248w" }
                               options: @{
                                 @"integrations": @{
                                         @"nielsen-dcr": @{

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -35,8 +35,8 @@ NSString *returnAdLoadType(NSDictionary *src, NSString *key)
 
 NSString *returnHasAdsStatus(NSDictionary *src, NSString *key)
 {
-    NSString *value = [src valueForKey:key];
-    if ([value isEqualToString:@YES]) {
+    NSNumber *value = [src valueForKey:key];
+    if ([value isEqual:@YES]) {
         return @"1";
     }
     return @"0";

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -158,7 +158,18 @@ NSDictionary *returnMappedAdContentProperties(NSDictionary *properties, NSDictio
         @"crossId2" : options[@"crossId2"] ?: @""
 
     };
-    return coerceToString(adContentMetadata);
+    
+    NSMutableDictionary *mutableAdContentMetadata = [adContentMetadata mutableCopy];
+    if (settings[@"subbrandPropertyName"]){
+        NSString *subbrandValue = properties[settings[@"subbrandPropertyName"]] ?: @"";
+        [mutableAdContentMetadata setObject:subbrandValue forKey:@"subbrand"];
+    }
+    
+    if (settings[@"clientIdPropertyName"]){
+        NSString *clientIdValue = properties[settings[@"clientIdPropertyName"]] ?: @"";
+        [mutableAdContentMetadata setObject:clientIdValue forKey:@"clientid"];
+    }
+    return coerceToString(mutableAdContentMetadata);
 }
 
 #pragma mark - Integration

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -42,6 +42,18 @@ NSString *returnHasAdsStatus(NSDictionary *src, NSString *key)
     return @"0";
 }
 
+NSString *returnCustomAssetId(NSDictionary *properties, NSString *defaultKey, NSDictionary *settings)
+{
+    NSString *customKey = settings[@"customAssetId"];
+    if (customKey){
+        NSString *value = [properties valueForKey:customKey];
+        return value;
+    } else {
+        NSString *value = [properties valueForKey:defaultKey];
+        return value;
+    }
+}
+
 long long returnPlayheadPosition(SEGTrackPayload *payload)
 {
     long long playheadPosition = 0;
@@ -81,12 +93,12 @@ NSDictionary *coerceToString(NSDictionary *map)
 #pragma mark Metadata Mapping
 #pragma mark -
 
-NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictionary *options)
+NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictionary *options, NSDictionary *settings)
 {
     NSDictionary *contentMetadata = @{
         @"pipmode" : options[@"pipmode"] ?: @"false",
         @"adloadtype" : returnAdLoadType(options, @"adLoadType"),
-        @"assetid" : properties[@"asset_id"] ?: @"",
+        @"assetid" : returnCustomAssetId(properties, @"asset_id", settings),
         @"type" : @"content",
         @"segB" : options[@"segB"] ?: @"",
         @"segC" : options[@"segC"] ?: @"",
@@ -294,7 +306,7 @@ NSDictionary *returnMappedAdContentProperties(NSDictionary *properties, NSDictio
 #pragma mark - Content Events
 
     if ([payload.event isEqualToString:@"Video Content Started"]) {
-        NSDictionary *contentMetadata = returnMappedContentProperties(properties, options);
+        NSDictionary *contentMetadata = returnMappedContentProperties(properties, options, self.settings);
         [self.nielsen loadMetadata:contentMetadata];
         SEGLog(@"[NielsenAppApi loadMetadata:%@]", contentMetadata);
         [self startPlayheadTimer:payload];

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -112,8 +112,19 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
         @"crossId1" : options[@"crossId1"] ?: @"",
         @"crossId2" : options[@"crossId2"] ?: @""
     };
+    
+    NSMutableDictionary *mutableContentMetada = [contentMetadata mutableCopy];
+    if (settings[@"subbrandPropertyName"]){
+        NSString *subbrandValue = properties[settings[@"subbrandPropertyName"]] ?: @"";
+        [mutableContentMetada setObject:subbrandValue forKey:@"subbrand"];
+    }
+    
+    if (settings[@"clientIdPropertyName"]){
+        NSString *clientIdValue = properties[settings[@"clientIdPropertyName"]] ?: @"";
+        [mutableContentMetada setObject:clientIdValue forKey:@"clientid"];
+    }
 
-    return coerceToString(contentMetadata);
+    return coerceToString(mutableContentMetada);
 }
 
 NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *options, NSDictionary *settings)


### PR DESCRIPTION
This PR updates `contentMetaData` handling: 
- [X] updates `hasAds` to properly handle boolean as int and not string 
- [X] leverages `settings[@"customAssetId"]` for customers to define a custom property to map to Nielsen `assetId`

These changes were tested with no breaking changes. 