### PR TITLE
Add support for custom ad assetId mapping

### DIFF
--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -56,7 +56,20 @@ NSString *returnContentLength(NSDictionary *src, NSString *defaultKey, NSDiction
 
 NSString *returnCustomAssetId(NSDictionary *properties, NSString *defaultKey, NSDictionary *settings)
 {
-    NSString *customKey = settings[@"assetIdPropertyName"];
+    NSString *customKey = settings[@"contentAssetIdPropertyName"];
+    NSString *value;
+    if (customKey){
+        value = [properties valueForKey:customKey];
+    } else {
+        value = [properties valueForKey:defaultKey];
+    }
+    value = value ? value : @"";
+    return value;
+}
+
+NSString *returnCustomAdAssetId(NSDictionary *properties, NSString *defaultKey, NSDictionary *settings)
+{
+    NSString *customKey = settings[@"adAssetIdPropertyName"];
     NSString *value;
     if (customKey){
         value = [properties valueForKey:customKey];
@@ -142,7 +155,7 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
 NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *options, NSDictionary *settings)
 {
     NSDictionary *adMetadata = @{
-        @"assetid" : returnCustomAssetId(properties, @"asset_id", settings),
+        @"assetid" : returnCustomAdAssetId(properties, @"asset_id", settings),
         @"type" : properties[@"type"] ?: @"",
         @"title" : properties[@"title"] ?: @""
 

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -54,7 +54,7 @@ NSString *returnContentLength(NSDictionary *src, NSString *defaultKey, NSDiction
     return contentLength;
 }
 
-NSString *returnCustomAssetId(NSDictionary *properties, NSString *defaultKey, NSDictionary *settings)
+NSString *returnCustomContentAssetId(NSDictionary *properties, NSString *defaultKey, NSDictionary *settings)
 {
     NSString *customKey = settings[@"contentAssetIdPropertyName"];
     NSString *value;
@@ -124,7 +124,7 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
     NSDictionary *contentMetadata = @{
         @"pipmode" : options[@"pipmode"] ?: @"false",
         @"adloadtype" : returnAdLoadType(options, @"adLoadType"),
-        @"assetid" : returnCustomAssetId(properties, @"asset_id", settings),
+        @"assetid" : returnCustomContentAssetId(properties, @"asset_id", settings),
         @"type" : @"content",
         @"segB" : options[@"segB"] ?: @"",
         @"segC" : options[@"segC"] ?: @"",
@@ -167,7 +167,7 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *o
 NSDictionary *returnMappedAdContentProperties(NSDictionary *properties, NSDictionary *options, NSDictionary *settings)
 {
     NSDictionary *adContentMetadata = @{
-        @"assetid" : returnCustomAssetId(properties, @"content_asset_id", settings),
+        @"assetid" : returnCustomContentAssetId(properties, @"content_asset_id", settings),
         @"pipmode" : options[@"pipmode"] ?: @"false",
         @"adloadtype" : returnAdLoadType(properties, @"load_type"),
         @"type" : @"content",


### PR DESCRIPTION
Add support for custom mapping for custom content asset id from settings `contentAssetIdPropertyName` and support for custom mapping for custom ad asset id from setting `adAssetIdPropertyName`.