### PR TITLE
Brie/nest preroll content

### DIFF
--- a/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
+++ b/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
@@ -16,13 +16,31 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    //https://segment.com/ladanazita/sources/video/debugger
     SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY_HERE"];
     [config use:[SEGNielsenDCRIntegrationFactory instance]];
     [SEGAnalytics setupWithConfiguration:config];
     [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
     [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
                            properties: @{ @"full_episode": @true, @"tms_video_id": @"3ru239ur829u4u8t480248w" }
+                              options: @{
+                                @"integrations": @{
+                                        @"nielsen-dcr": @{
+                                          @"pipmode": @"2017-05-22",
+                                          @"adLoadType": @"c3 value",
+                                          @"channelName": @"c4 value",
+                                          @"mediaUrl": @"c6 value",
+                                          @"hasAds": @true,
+                                          @"crossId1": @"cross id1 value",
+                                          @"crossId2": @"cross id2 value"
+                                         }
+                                       }
+                            }];
+
+    [[SEGAnalytics sharedAnalytics] track:@"Video Ad Started"
+                           properties: @{ @"type": @"pre-roll", @"full_episode": @true, @"tms_video_id": @"3ru239ur829u4u8t480248w",
+                                          @"content": @{
+                                            @"title": @"Hello World"
+                                          }}
                               options: @{
                                 @"integrations": @{
                                         @"nielsen-dcr": @{
@@ -45,29 +63,29 @@
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+   // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+   // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+   // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+   // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
 {
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+   // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+   // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application
 {
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+   // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
 @end

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -48,9 +48,12 @@ NSString *returnContentLength(NSDictionary *src, NSString *defaultKey, NSDiction
     NSString *contentLength;
     if (contentLengthKey) {
         contentLength = [src valueForKey:contentLengthKey];
-    } else {
+    } else if (src[@"total_length"]) {
        contentLength = [src valueForKey:@"total_length"];
+    } else {
+        contentLength = @"";
     }
+    
     return contentLength;
 }
 
@@ -60,10 +63,11 @@ NSString *returnCustomContentAssetId(NSDictionary *properties, NSString *default
     NSString *value;
     if (customKey){
         value = [properties valueForKey:customKey];
-    } else {
+    } else if (properties[defaultKey]) {
         value = [properties valueForKey:defaultKey];
+    } else {
+        value = @"";
     }
-    value = value ? value : @"";
     return value;
 }
 
@@ -73,10 +77,11 @@ NSString *returnCustomAdAssetId(NSDictionary *properties, NSString *defaultKey, 
     NSString *value;
     if (customKey){
         value = [properties valueForKey:customKey];
-    } else {
+    } else if (properties[defaultKey])  {
         value = [properties valueForKey:defaultKey];
+    } else {
+        value = @"";
     }
-    value = value ? value : @"";
     return value;
 }
 
@@ -379,7 +384,8 @@ NSDictionary *returnMappedAdContentProperties(NSDictionary *properties, NSDictio
 
         // In case of ad `type` preroll, call `loadMetadata` with metadata values for content, followed by `loadMetadata` with ad (preroll) metadata
         if ([properties[@"type"] isEqualToString:@"pre-roll"]) {
-            NSDictionary *adContentMetadata = returnMappedAdContentProperties(properties, options, self.settings);
+            NSDictionary *contentProperties = [properties valueForKey:@"content"];
+            NSDictionary *adContentMetadata = returnMappedAdContentProperties(contentProperties, options, self.settings);
             [self.nielsen loadMetadata:adContentMetadata];
             SEGLog(@"[NielsenAppApi loadMetadata:%@]", adContentMetadata);
         }


### PR DESCRIPTION
1. Fixes a bug with `content_length` helper function that caused app to crash when custom prop was not passed and default `content_length` prop was not passed. Fixed bug to default to setting Nielsen metadata property `length` to `@""` when these conditions are met. 

2. Updates pre-roll ad `loadMetadata`. Previously we were retrieving properties for content from `properties` object which does not adhere to the Segment video spec. This PR changes the properties to be retrieved from the `properties.content` object on a pre-roll ad event. 