### PR TITLE
Brie/update load type

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -283,42 +283,6 @@ describe(@"SEGNielsenDCRIntegration", ^{
         }];
     });
 
-    it(@"tracks Video Content Started with loadType in integration options", ^{
-        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Started" properties:@{
-            @"asset_id" : @"3543",
-            @"pod_id" : @"65462",
-            @"title" : @"Big Trouble in Little Sanchez",
-            @"season" : @"2",
-            @"episode" : @"7",
-            @"genre" : @"cartoon",
-            @"program" : @"Rick and Morty",
-            @"total_length" : @400,
-            @"full_episode" : @YES,
-            @"publisher" : @"Turner Broadcasting Network",
-            @"position" : @22,
-            @"channel" : @"Cartoon Network",
-            @"airdate": @""
-        } context:@{}
-         integrations:@{ @"nielsen-dcr": @{ @"loadType": @"dynamic"}}];
-        [integration track:payload];
-        [verify(mockNielsenAppApi) loadMetadata:@{
-            @"pipmode" : @"false",
-            @"adloadtype" : @"2",
-            @"assetid" : @"3543",
-            @"type" : @"content",
-            @"segB" : @"",
-            @"segC" : @"",
-            @"title" : @"Big Trouble in Little Sanchez",
-            @"program" : @"Rick and Morty",
-            @"isfullepisode" : @"y",
-            @"airdate" : @"",
-            @"length" : @"400",
-            @"crossId1" : @"",
-            @"crossId2" : @"",
-            @"hasAds" : @"0"
-        }];
-    });
-
     it(@"tracks Video Content Started with loadType in properties", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Started" properties:@{
             @"asset_id" : @"3543",

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -283,6 +283,80 @@ describe(@"SEGNielsenDCRIntegration", ^{
         }];
     });
 
+    it(@"tracks Video Content Started with loadType in integration options", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Started" properties:@{
+            @"asset_id" : @"3543",
+            @"pod_id" : @"65462",
+            @"title" : @"Big Trouble in Little Sanchez",
+            @"season" : @"2",
+            @"episode" : @"7",
+            @"genre" : @"cartoon",
+            @"program" : @"Rick and Morty",
+            @"total_length" : @400,
+            @"full_episode" : @YES,
+            @"publisher" : @"Turner Broadcasting Network",
+            @"position" : @22,
+            @"channel" : @"Cartoon Network",
+            @"airdate": @""
+        } context:@{}
+         integrations:@{ @"nielsen-dcr": @{ @"loadType": @"dynamic"}}];
+        [integration track:payload];
+        [verify(mockNielsenAppApi) loadMetadata:@{
+            @"pipmode" : @"false",
+            @"adloadtype" : @"2",
+            @"assetid" : @"3543",
+            @"type" : @"content",
+            @"segB" : @"",
+            @"segC" : @"",
+            @"title" : @"Big Trouble in Little Sanchez",
+            @"program" : @"Rick and Morty",
+            @"isfullepisode" : @"y",
+            @"airdate" : @"",
+            @"length" : @"400",
+            @"crossId1" : @"",
+            @"crossId2" : @"",
+            @"hasAds" : @"0"
+        }];
+    });
+
+    it(@"tracks Video Content Started with loadType in properties", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Started" properties:@{
+            @"asset_id" : @"3543",
+            @"pod_id" : @"65462",
+            @"title" : @"Big Trouble in Little Sanchez",
+            @"season" : @"2",
+            @"episode" : @"7",
+            @"genre" : @"cartoon",
+            @"program" : @"Rick and Morty",
+            @"total_length" : @400,
+            @"full_episode" : @YES,
+            @"publisher" : @"Turner Broadcasting Network",
+            @"position" : @22,
+            @"channel" : @"Cartoon Network",
+            @"airdate": @"",
+            @"loadType": @"dynamic"
+        } context:@{}
+            integrations:@{}];
+        [integration track:payload];
+        [verify(mockNielsenAppApi) loadMetadata:@{
+            @"pipmode" : @"false",
+            @"adloadtype" : @"2",
+            @"assetid" : @"3543",
+            @"type" : @"content",
+            @"segB" : @"",
+            @"segC" : @"",
+            @"title" : @"Big Trouble in Little Sanchez",
+            @"program" : @"Rick and Morty",
+            @"isfullepisode" : @"y",
+            @"airdate" : @"",
+            @"length" : @"400",
+            @"crossId1" : @"",
+            @"crossId2" : @"",
+            @"hasAds" : @"0"
+        }];
+    });
+
+
     it(@"tracks Video Content Completed", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Completed" properties:@{
             @"asset_id" : @"3543",

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -24,9 +24,17 @@ NSString *returnFullEpisodeStatus(NSDictionary *src, NSString *key)
 }
 
 
-NSString *returnAdLoadType(NSDictionary *src, NSString *key)
+NSString *returnAdLoadType(NSDictionary *options, NSDictionary *properties)
 {
-    NSString *value = [src valueForKey:key];
+    NSString *value;
+    if ([options valueForKey:@"adLoadType"]){
+        value = [options valueForKey:@"adLoadType"];
+    } else if ([options valueForKey:@"loadType"]) {
+        value = [options valueForKey:@"loadType"];
+    } else if ([properties valueForKey:@"loadType"]){
+        value = [properties valueForKey:@"loadType"];
+    }
+    
     if ([value isEqualToString:@"dynamic"]) {
         return @"2";
     }
@@ -168,7 +176,7 @@ NSDictionary *returnMappedContentProperties(NSDictionary *properties, NSDictiona
 {
     NSDictionary *contentMetadata = @{
         @"pipmode" : options[@"pipmode"] ?: @"false",
-        @"adloadtype" : returnAdLoadType(options, @"adLoadType"),
+        @"adloadtype" : returnAdLoadType(options, properties),
         @"assetid" : returnCustomContentAssetId(properties, @"asset_id", settings),
         @"type" : @"content",
         @"segB" : options[@"segB"] ?: @"",

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -29,8 +29,6 @@ NSString *returnAdLoadType(NSDictionary *options, NSDictionary *properties)
     NSString *value;
     if ([options valueForKey:@"adLoadType"]){
         value = [options valueForKey:@"adLoadType"];
-    } else if ([options valueForKey:@"loadType"]) {
-        value = [options valueForKey:@"loadType"];
     } else if ([properties valueForKey:@"loadType"]){
         value = [properties valueForKey:@"loadType"];
     }


### PR DESCRIPTION
Falls back to look for `loadType` in the payload properties only if `adLoadType` doesn’t exist in options. Fox will only be passing `loadType` as a property: