### PR TITLE
[1007] Hard code "dcr" as value of sfcode setting.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - OCHamcrest (6.1.1)
   - OCMockito (4.1.0):
     - OCHamcrest (~> 6.0)
-  - Segment-Nielsen-DCR (1.1.2):
+  - Segment-Nielsen-DCR (1.2.5):
     - Analytics (~> 3.6)
   - Specta (1.0.6)
 
@@ -31,9 +31,9 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: 363e1bf738c3e8a94abe7c2c415f70d671adde38
   OCMockito: bceefcd365252bcdf8b59c1b2bd23890805fc0d8
-  Segment-Nielsen-DCR: 90eadf03d4de5d499cbc604abaab8d0da8ad4fd1
+  Segment-Nielsen-DCR: 38def21988f755267aca1cf557cc7ebde22b2722
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
 PODFILE CHECKSUM: e793c123c1317f200d9e9259817fe1554d7e08ed
 
-COCOAPODS: 1.7.3
+COCOAPODS: 1.7.5

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -21,7 +21,7 @@ describe(@"SEGNielsenDCRIntegration", ^{
             @"appid" : @"TXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
             @"appname" : @"Test",
             @"appversion" : @"0.1",
-            @"sfcode" : @"dcr-cert"
+            @"sfcode" : @"dcr"
         };
 
 

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -196,19 +196,13 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *o
 
         NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
         NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
-        NSString *sfCode;
-
-        if (settings[@"sfCode"]) {
-            sfCode = @"dcr";
-        } else {
-            sfCode = @"dcr-cert";
-        }
 
         NSMutableDictionary *appInformation = [[NSMutableDictionary alloc] initWithDictionary: @{
             @"appid" : settings[@"appId"] ?: @"",
             @"appname" : appName ?: @"",
             @"appversion" : appVersion ?: @"",
-            @"sfcode" : sfCode
+            // hard-coding sfcode to "dcr" per request from Nielsen's support team
+            @"sfcode" : @"dcr";
         }];
 
         if ([settings[@"nolDevDebug"] boolValue]) {


### PR DESCRIPTION
This is the CI build we care about: https://circleci.com/gh/segment-integrations/analytics-ios-integration-nielsen-dcr/67

https://segment.atlassian.net/browse/DEST-1007

Per Nielsen, the value of "sfcode" should always be "dcr" from now on, so we are going to hard code that value and hide the UI setting.