### PR TITLE
[DEST-1176] Update Makefile and Circle Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,18 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: "9.4.1"
+      xcode: "11.0"
     steps:
       - checkout
       - run: xcrun simctl list
+      - run:
+          name: Add Nielsen credentials
+          command: |
+            cat >~/.netrc <<EOF
+              machine $NIELSEN_MACHINE
+              login $NIELSEN_SDK_LOGIN
+              password $NIELSEN_SDK_PASSWORD
+            EOF
       - run:
           name: Install build dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
           command: |
             sudo gem install xcpretty
             sudo gem install cocoapods -v 1.6.1
-      # - run:
-      #     name: Fetch Cocoapods specs
-      #     command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - run:
+          name: Fetch Cocoapods specs
+          command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
 
       - run: make install
       - run: make build

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,7 +1,9 @@
+source 'https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git'
 use_frameworks!
 
 target 'Segment-Nielsen-DCR_Example' do
   pod 'Segment-Nielsen-DCR', :path => '../'
+  pod 'NielsenAppSDK', '6.2.0.0'
 
   target 'Segment-Nielsen-DCR_Tests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - OCHamcrest (6.1.1)
   - OCMockito (4.1.0):
     - OCHamcrest (~> 6.0)
-  - Segment-Nielsen-DCR (1.1.2):
+  - Segment-Nielsen-DCR (1.2.8):
     - Analytics (~> 3.6)
   - Specta (1.0.6)
 
@@ -31,9 +31,9 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: 363e1bf738c3e8a94abe7c2c415f70d671adde38
   OCMockito: bceefcd365252bcdf8b59c1b2bd23890805fc0d8
-  Segment-Nielsen-DCR: 90eadf03d4de5d499cbc604abaab8d0da8ad4fd1
+  Segment-Nielsen-DCR: 2265f705e6ba9112d228a36d380f964ce4578979
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
 PODFILE CHECKSUM: e793c123c1317f200d9e9259817fe1554d7e08ed
 
-COCOAPODS: 1.7.3
+COCOAPODS: 1.7.5

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,7 @@
 PODS:
   - Analytics (3.6.3)
   - Expecta (1.0.6)
+  - NielsenAppSDK (6.2.0.0)
   - OCHamcrest (6.1.1)
   - OCMockito (4.1.0):
     - OCHamcrest (~> 6.0)
@@ -10,6 +11,7 @@ PODS:
 
 DEPENDENCIES:
   - Expecta
+  - NielsenAppSDK (= 6.2.0.0)
   - OCMockito
   - Segment-Nielsen-DCR (from `../`)
   - Specta
@@ -21,6 +23,8 @@ SPEC REPOS:
     - OCHamcrest
     - OCMockito
     - Specta
+  https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git:
+    - NielsenAppSDK
 
 EXTERNAL SOURCES:
   Segment-Nielsen-DCR:
@@ -29,11 +33,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Analytics: be561304471ed2aa58c4881fea59362dc7bbb4a5
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
+  NielsenAppSDK: be0732f26810c30d4353148d433cfe9da4bf2f96
   OCHamcrest: 363e1bf738c3e8a94abe7c2c415f70d671adde38
   OCMockito: bceefcd365252bcdf8b59c1b2bd23890805fc0d8
   Segment-Nielsen-DCR: 2265f705e6ba9112d228a36d380f964ce4578979
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
-PODFILE CHECKSUM: e793c123c1317f200d9e9259817fe1554d7e08ed
+PODFILE CHECKSUM: 4d5c8b53ee9e350462debbc3036f2ef4a5d85905
 
 COCOAPODS: 1.7.5

--- a/Example/Segment-Nielsen-DCR.xcodeproj/project.pbxproj
+++ b/Example/Segment-Nielsen-DCR.xcodeproj/project.pbxproj
@@ -402,10 +402,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Segment-Nielsen-DCR_Example/Pods-Segment-Nielsen-DCR_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Analytics/Analytics.framework",
+				"${PODS_ROOT}/NielsenAppSDK/NielsenAppApi.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Analytics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NielsenAppApi.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Segment-Nielsen-DCR.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Segment-Nielsen-DCR.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Segment-Nielsen-DCR.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/Segment-Nielsen-DCR.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
-XCPRETTY := xcpretty -c && exit ${PIPESTATUS[0]}
+XCPRETTY := xcpretty -c
 
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 5"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 8"
 PROJECT := Segment-Nielsen-DCR
 XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 
@@ -14,9 +14,15 @@ clean:
 	xcodebuild $(XC_ARGS) clean | $(XCPRETTY)
 
 build:
+	xcodebuild $(XC_ARGS)
+
+build-dev:
 	xcodebuild $(XC_ARGS) | $(XCPRETTY)
 
 test:
+	xcodebuild test $(XC_ARGS)
+
+test-dev:
 	xcodebuild test $(XC_ARGS) | $(XCPRETTY)
 
 lint:
@@ -28,5 +34,5 @@ xcbuild:
 xctest:
 	xctool test $(XC_ARGS)
 
-.PHONY: test build xctest xcbuild clean
+.PHONY: test test-dev build build-dev xctest xcbuild clean
 .SILENT:


### PR DESCRIPTION
https://segment.atlassian.net/browse/DEST-1176

This PR updates the repo's Makefile and Circle config so that Circle properly reports when jobs have passed or failed. Previously, Circle would mark all jobs as passing, as the exit code for various make commands was not properly exposed. Now, all exit codes should be properly exposed, and Circle will fail on build and test if something is wrong.

This update does not require a CC ticket as it does not alter the functionality of the SDK. In addition, we won't cut a new release since the changes in this PR serve only to ensure our CI workflow reports the correct exit code of each command.

TO DO: Cut down on build time - the current Circle workflow runs in about ~10 minutes.