### PR TITLE
Remove version pinning

### DIFF
--- a/Segment-Nielsen-DCR.podspec
+++ b/Segment-Nielsen-DCR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Segment-Nielsen-DCR'
-  s.version          = '1.3.1'
+  s.version          = '1.3.2'
   s.summary          = "Nielsen DCR Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
 
   s.preserve_paths = 'Segment-Nielsen-DCR/Classes/**/*'
 
-  s.dependency 'Analytics', '~> 3.6'
+  s.dependency 'Analytics'
 
 end


### PR DESCRIPTION
The version pinning on Nielsen DCR is blocking Fox from updating to the latest ios library (4.0.1). which is necessary for them to resolve other open issues. It also restricts them from using new features like destinationMiddlewares in analytics-ios 4.x. This is high urgency for Fox. Please let me know if any testing is needed to merge this and I can do so!

FYI I think we need to update the changelog to include version 1.3.2 of this integration once approved - if so, let me know and I can do this as well.