### PR TITLE
[STRATCONN-419] Update namespacing ios14

### DIFF
--- a/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
+++ b/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
@@ -8,7 +8,7 @@
 
 #import "SEGNielsenDCRAppDelegate.h"
 #import "SEGNielsenDCRIntegrationFactory.h"
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
 #else
 #import <Segment/SEGAnalytics.h>

--- a/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
+++ b/Example/Segment-Nielsen-DCR/SEGNielsenDCRAppDelegate.m
@@ -8,7 +8,11 @@
 
 #import "SEGNielsenDCRAppDelegate.h"
 #import "SEGNielsenDCRIntegrationFactory.h"
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGAnalytics.h>
+#else
+#import <Segment/SEGAnalytics.h>
+#endif
 //#import <NielsenAppApi/NielsenAppApi.h>
 
 

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.h
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.h
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegration.h>
 #else
 #import <Segment/SEGIntegration.h>

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.h
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegration.h>
+#else
+#import <Segment/SEGIntegration.h>
+#endif
 #import <NielsenAppApi/NielsenAppApi.h>
 
 

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -7,7 +7,11 @@
 //
 
 #import "SEGNielsenDCRIntegration.h"
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGAnalyticsUtils.h>
+#else
+#import <Segment/SEGAnalyticsUtils.h>
+#endif
 #import <NielsenAppApi/NielsenAppApi.h>
 
 #pragma mark -

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -7,7 +7,7 @@
 //
 
 #import "SEGNielsenDCRIntegration.h"
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalyticsUtils.h>
 #else
 #import <Segment/SEGAnalyticsUtils.h>

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegrationFactory.h
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegrationFactory.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
 #else
 #import <Segment/SEGIntegrationFactory.h>

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegrationFactory.h
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegrationFactory.h
@@ -7,8 +7,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
-
+#else
+#import <Segment/SEGIntegrationFactory.h>
+#endif
 
 @interface SEGNielsenDCRIntegrationFactory : NSObject <SEGIntegrationFactory>
 


### PR DESCRIPTION
https://paper.dropbox.com/doc/PRD-Analytics-iOS-Namespace-Change--A89lGjxWJiMUgRtRmVL5aN1UAg-FewzU7P1dJM5yKVEgfenA

Segment’s iOS SDK was namespaced to SEGAnalytics under the Objective-C naming convention. As we modernized the SDK to support Swift and more package managers beyond Cocoapods such as Swift Package Manager and Carthage the namespace was renamed to Analytics in-line with Swift idioms as well as Package Manager requirements. It was released as beta. We have received customer feedback that this is leading to namespace collisions and are now going to change this to a much clearer namespace: Segment and the community prefer this as well.