### PR TITLE
update event mappings and remove +1 from playhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Version 1.5.0 *(7th April, 2021)*
+-------------------------------------------
+* Updates `Video Playback Started` to call `play` and load content metadata.
+* Updates `Video Playback Interrupted` to call `stop`.
+* Maps `Video Playback Exited` to call `stop`.
+* Removes `+1` increment to playhead when `position` = 0.
+* Adds support for setting to map custom property to Nielsen's page/screen `section`, with fallback to `name` field.
+
 Version 1.4.0 *(9th October, 2020)*
 -------------------------------------------
 * Updates Nielsen SDK to 8.x

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -73,21 +73,46 @@ describe(@"SEGNielsenDCRIntegration", ^{
 
     it(@"tracks Video Playback Started", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Playback Started" properties:@{
+            @"airdate": @"2005-06-27T21:00:00Z",
+            @"asset_id" : @"1234",
             @"content_asset_id" : @"1234",
             @"ad_type" : @"pre-roll",
             @"video_player" : @"youtube",
-            @"position" : @1
+            @"position" : @1,
+            @"title" : @"Big Trouble in Little Sanchez",
+            @"season" : @"2",
+            @"episode" : @"7",
+            @"genre" : @"cartoon",
+            @"program" : @"Rick and Morty",
+            @"total_length" : @400,
+            @"full_episode" : @YES,
+            @"publisher" : @"Turner Broadcasting Network
         } context:@{}
             integrations:@{}];
-
         [integration track:payload];
+        [verify(mockNielsenAppApi) loadMetadata:@{
+            @"pipmode" : @"false",
+            @"adloadtype" : @"1",
+            @"assetid" : @"1234",
+            @"type" : @"content",
+            @"segB" : @"",
+            @"segC" : @"",
+            @"title" : @"Big Trouble in Little Sanchez",
+            @"program" : @"Rick and Morty",
+            @"isfullepisode" : @"y",
+            @"airdate" : @"20050627 21:00:00",
+            @"length" : @"400",
+            @"crossId1" : @"",
+            @"crossId2" : @"",
+            @"hasAds" : @"0"
+        }];
         [verify(mockNielsenAppApi) play:@{
             @"channelName" : @"defaultChannelName",
             @"mediaURL" : @""
         }];
     });
 
-     it(@"tracks Video Playback Resumed", ^{
+    it(@"tracks Video Playback Resumed", ^{
          SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Playback Resumed" properties:@{
             @"content_asset_id" : @"1234",
             @"ad_type" : @"pre-roll",
@@ -188,8 +213,26 @@ describe(@"SEGNielsenDCRIntegration", ^{
             integrations:@{}];
 
         [integration track:payload];
-        [(NielsenAppApi *)verify(mockNielsenAppApi) end];
+        [(NielsenAppApi *)verify(mockNielsenAppApi) stop];
     });
+    
+    it(@"tracks Video Playback Exited", ^{
+        SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Playback Exited" properties:@{
+            @"content_asset_id" : @"7890",
+            @"ad_type" : @"mid-roll",
+            @"video_player" : @"vimeo",
+            @"position" : @30,
+            @"sound" : @100,
+            @"full_screen" : @YES,
+            @"bitrate" : @50
+        }
+            context:@{}
+            integrations:@{}];
+
+        [integration track:payload];
+        [(NielsenAppApi *)verify(mockNielsenAppApi) stop];
+    });
+
 
     it(@"tracks Video Playback Completed", ^{
         SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Playback Completed" properties:@{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -86,7 +86,7 @@ describe(@"SEGNielsenDCRIntegration", ^{
             @"program" : @"Rick and Morty",
             @"total_length" : @400,
             @"full_episode" : @YES,
-            @"publisher" : @"Turner Broadcasting Network
+            @"publisher" : @"Turner Broadcasting Network"
         } context:@{}
             integrations:@{}];
         [integration track:payload];

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Nielsen App SDK as of version 6.0.0.0 is compatible with Apple iOS version 8
 Segment-Nielsen-DCR SDK is not available through [CocoaPods](http://cocoapods.org) trunk due to Nielsen's SDK being in a private spec repo. To install the Segment-Nielsen-DCR pod, add the following line to your Podfile:
 
 ```ruby
-pod "Segment-Nielsen-DCR", :git => 'https://github.com/segment-integrations/analytics-ios-integration-nielsen-dcr.git', :tag => '1.4.0'
+pod "Segment-Nielsen-DCR", :git => 'https://github.com/segment-integrations/analytics-ios-integration-nielsen-dcr.git', :tag => '1.5.0'
 ```
 
 The integration relies on the the Nielsen framework, which can either be installed via Cocoapods or by manually adding the framework. You will need to have a Nielsen representative to get started.

--- a/Segment-Nielsen-DCR.podspec
+++ b/Segment-Nielsen-DCR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Segment-Nielsen-DCR'
-  s.version          = '1.4.0'
+  s.version          = '1.5.0'
   s.summary          = "Nielsen DCR Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC

--- a/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
+++ b/Segment-Nielsen-DCR/Classes/SEGNielsenDCRIntegration.m
@@ -286,7 +286,7 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *o
 
 - (void)playHeadTimeEvent:(NSTimer *)timer
 {
-    self.startingPlayheadPosition = self.startingPlayheadPosition + 1;
+    self.startingPlayheadPosition = self.startingPlayheadPosition;
 
     [self.nielsen playheadPosition:self.startingPlayheadPosition];
     SEGLog(@"[NielsenAppApi playheadPosition: %d]", self.startingPlayheadPosition);
@@ -325,8 +325,24 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *o
     NSDictionary *options = [payload.integrations valueForKey:@"nielsen-dcr"];
 #pragma mark Playback Events
 
-    if ([payload.event isEqualToString:@"Video Playback Started"] ||
-        [payload.event isEqualToString:@"Video Playback Resumed"] ||
+    // Nielsen requires we load content metadata and call play upon playback start
+    if ([payload.event isEqualToString:@"Video Playback Started"]) {
+        NSDictionary *channelInfo = @{
+            // channelName is optional for DCR, if not present Nielsen asks to set default
+            @"channelName" : options[@"channelName"] ?: @"defaultChannelName",
+            // if mediaURL is not available, Nielsen expects an empty value
+            @"mediaURL" : options[@"mediaUrl"] ?: @""
+        };
+        NSDictionary *contentMetadata = returnMappedContentProperties(properties, options, self.settings);
+        [self.nielsen loadMetadata:contentMetadata];
+        SEGLog(@"[NielsenAppApi loadMetadata:%@]", contentMetadata);
+        [self startPlayheadTimer:payload];
+        [self.nielsen play:channelInfo];
+        SEGLog(@"[NielsenAppApi play: %@]", channelInfo);
+        return;
+    }
+
+    if ([payload.event isEqualToString:@"Video Playback Resumed"] ||
         [payload.event isEqualToString:@"Video Playback Seek Completed"] ||
         [payload.event isEqualToString:@"Video Playback Buffer Completed"]) {
         NSDictionary *channelInfo = @{
@@ -344,15 +360,16 @@ NSDictionary *returnMappedAdProperties(NSDictionary *properties, NSDictionary *o
 
     if ([payload.event isEqualToString:@"Video Playback Paused"] ||
         [payload.event isEqualToString:@"Video Playback Seek Started"] ||
-        [payload.event isEqualToString:@"Video Playback Buffer Started"]) {
+        [payload.event isEqualToString:@"Video Playback Buffer Started"] ||
+        [payload.event isEqualToString:@"Video Playback Interrupted"] ||
+        [payload.event isEqualToString:@"Video Playback Exited"]) {
         [self stopPlayheadTimer:payload];
         [self.nielsen stop];
         SEGLog(@"[NielsenAppApi stop]");
         return;
     }
 
-    if ([payload.event isEqualToString:@"Video Playback Interrupted"] ||
-        [payload.event isEqualToString:@"Video Playback Completed"]) {
+    if ([payload.event isEqualToString:@"Video Playback Completed"]) {
         [self stopPlayheadTimer:payload];
         [self.nielsen end];
         SEGLog(@"[NielsenAppApi end]");


### PR DESCRIPTION
This PR does the following, as per Nielsen requirements:

- Update mapping for Video Playback Interrupted to call `stop` instead of `end`
- Add mapping for Video Playback Exited to call `stop`. This new event has been approved by the spec committee. See here: https://paper.dropbox.com/doc/Video-Spec-Event-Proposal-for-Video-Playback-Exited--A8j5DFZuVoZYlsG~ZQr96tlcAg-rUDm4tQEB1RsdH0R7Xujm
- Update mapping for Video Playback Started to load content metadata and call `play`
- Remove +1 from playhead, as Nielsen told us that adding 1 to playheads is only required on web and should not be done on mobile

Test file also updated. Unit tests and local testing in progress.